### PR TITLE
Moved project environment variables to .env file

### DIFF
--- a/airflow/dags/ingest-crime-data-to-gcs.py
+++ b/airflow/dags/ingest-crime-data-to-gcs.py
@@ -23,7 +23,7 @@ import pandas as pd
 PROJECT_ID = os.environ.get("GCP_PROJECT_ID")
 BUCKET_ID = os.environ.get("GCP_GCS_BUCKET")
 BIGQUERY_DATASET = os.environ.get("BIGQUERY_DATASET", "sf_crime_data_all")
-APP_TOKEN = ""
+APP_TOKEN = os.environ.get("SODA_APP_TOKEN")
 
 dataset_soda_api_url = "https://data.sfgov.org/resource/wg3w-h783.json"
 dataset_date_field = "incident_date"

--- a/airflow/docker-compose.yaml
+++ b/airflow/docker-compose.yaml
@@ -62,10 +62,8 @@ x-airflow-common:
     AIRFLOW__API__AUTH_BACKENDS: 'airflow.api.auth.backend.basic_auth'
     _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:-}
     
-    GCP_PROJECT_ID: sf-crime-76032
-    GCP_GCS_BUCKET: sf-crime-data-lake
-    GOOGLE_APPLICATION_CREDENTIALS: /.google/credentials/etl-sf-crime-76032-credentials.json
-    AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT: google-cloud-platform://?extra__google_cloud_platform__key_path=/.google/credentials/etl-sf-crime-76032-credentials.json
+  env_file:
+    - .env
 
   volumes:
     - ./dags:/opt/airflow/dags


### PR DESCRIPTION
Move Google Cloud Storage environmental variables out of docker-compose.yaml and moved them to .env file (locally) as not to disclose publically Google Cloud project information.

In ingest_data_crime_data_to_gcs.py, retrieved SODA API app token from the environment variable APP_TOKEN.
