### PR TITLE
Test removing file from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Small example of an data pipeline using San Francisco Police department incident
 
 ## Required Components
 
-* [Google Cloud Platform](./gcp/README.md)
+* [Google Cloud Platform](./gcp/)
 * [Terraform](./terraform/README.md)
 * [Apache Airflow](./airflow/README.md)
 * [dbt](./dbt/README.md)


### PR DESCRIPTION
test removal of README link from the GCP link in the main README.md file.

Should display the folder contents as well as README file.