### PR TITLE
Removed README.md from links to project folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ Small example of an data pipeline using San Francisco Police department incident
 ## Required Components
 
 * [Google Cloud Platform](./gcp/)
-* [Terraform](./terraform/README.md)
-* [Apache Airflow](./airflow/README.md)
-* [dbt](./dbt/README.md)
+* [Terraform](./terraform/)
+* [Apache Airflow](./airflow/)
+* [dbt](./dbt/)

--- a/SQL/README.md
+++ b/SQL/README.md
@@ -6,4 +6,4 @@ Replace the "external_incident_data" with the full BigQuery path to the database
 
 The external_incident_data BigQuery table will be used as the basis of the data warehouse.  dbt will transform this data into it's final data warehouse format.
 
-Next go to [dbt](../dbt/README.md) to transform the incident data.
+Next go to [dbt](../dbt/) to transform the incident data.

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -58,4 +58,4 @@ For this project, I decided to retreive the past 2 years worth of incident repor
 
 After this command executes, the Google Cloud Storage bucket should contain 2 years' worth of incident report data.
 
-Go to the [SQL](../SQL/README.md) folder to execute the SQL statement in BigQuery to load the dataset.
+Go to the [SQL](../SQL/) folder to execute the SQL statement in BigQuery to load the dataset.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -30,4 +30,4 @@ Delete infrastructure after you complete your work to avoid costs on any running
 
     terraform destroy
 
-Now the infrastructure is ready to be used by [Airflow](../airflow/README.md).
+Now the infrastructure is ready to be used by [Airflow](../airflow/).


### PR DESCRIPTION
Removed the link to README.md from all of the markdown files that point to a specific project folder; i.e ./gcp/ instead of ./gcp/README.md.

This has the effect of showing the user the README file as well as the contents of the folder itself when the user clicks on the link from the previous page.